### PR TITLE
added chalk as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "chai": "^3.3.0",
     "chai-as-promised": "^5.1.0",
+    "chalk": "^1.1.1",
     "configstore": "^1.2.1",
     "cpr": "^0.4.2",
     "debug": "^2.2.0",


### PR DESCRIPTION
We're using chalk here: https://github.com/ember-cli/ember-cli-internal-test-helpers/blob/07527cdca9ce357b101c0fe6f85b9c7084949a3d/lib/helpers/run-command.js#L4
