### PR TITLE
Add the ability to mock any 'taskFor' targets

### DIFF
--- a/lib/helpers/disable-npm-on-blueprint.js
+++ b/lib/helpers/disable-npm-on-blueprint.js
@@ -3,7 +3,7 @@ var MockBlueprintTaskFor = require('./mock-blueprint-task-for');
 
 module.exports = {
   disableNPM: function(Blueprint) {
-    MockBlueprintTaskFor.disableTasks(Blueprint);
+    MockBlueprintTaskFor.disableTasks(Blueprint, ['npm-install']);
   },
 
   restoreNPM: function(Blueprint) {

--- a/lib/helpers/disable-npm-on-blueprint.js
+++ b/lib/helpers/disable-npm-on-blueprint.js
@@ -1,25 +1,12 @@
 'use strict';
-var assert        = require('./assert');
-var originTaskFor;
-var Promise       = require('rsvp');
+var MockBlueprintTaskFor = require('./mock-blueprint-task-for');
 
 module.exports = {
   disableNPM: function(Blueprint) {
-    originTaskFor = Blueprint.prototype.taskFor;
-    Blueprint.prototype.taskFor = function(taskName) {
-      // we don't actually need to run the npm-install task, so lets mock it to
-      // speedup tests that need it
-      assert.equal(taskName, 'npm-install');
-
-      return {
-        run: function() {
-          return Promise.resolve();
-        }
-      };
-    };
+    MockBlueprintTaskFor.disableTasks(Blueprint, [ 'npm-install' ]);
   },
 
   restoreNPM: function(Blueprint) {
-    Blueprint.prototype.taskFor = originTaskFor;
+    MockBlueprintTaskFor.restoreTasks(Blueprint);
   }
 };

--- a/lib/helpers/disable-npm-on-blueprint.js
+++ b/lib/helpers/disable-npm-on-blueprint.js
@@ -3,7 +3,7 @@ var MockBlueprintTaskFor = require('./mock-blueprint-task-for');
 
 module.exports = {
   disableNPM: function(Blueprint) {
-    MockBlueprintTaskFor.disableTasks(Blueprint, [ 'npm-install' ]);
+    MockBlueprintTaskFor.disableTasks(Blueprint);
   },
 
   restoreNPM: function(Blueprint) {

--- a/lib/helpers/mock-blueprint-task-for.js
+++ b/lib/helpers/mock-blueprint-task-for.js
@@ -1,15 +1,14 @@
 'use strict';
-var originTaskFor;
-var Promise       = require('rsvp');
-var tasksToMock = [];
+var originalTaskForFn;
+var Promise     = require('rsvp');
+var tasksToMock = ['npm-install'];
 
 module.exports = {
-  disableTasks: function(Blueprint, tasks) {
-    originTaskFor = Blueprint.prototype.taskFor;
-    tasksToMock = tasks;
+  disableTasks: function(Blueprint) {
+    originalTaskForFn = Blueprint.prototype.taskFor;
 
     Blueprint.prototype.taskFor = function(taskName) {
-
+      console.log(tasksToMock, taskName);
       if (tasksToMock.indexOf(taskName) !== -1) {
         return {
           run: function() {
@@ -18,13 +17,12 @@ module.exports = {
         };
       }
 
-      return originTaskFor.call(this, taskName);
+      return originalTaskForFn.call(this, taskName);
     };
   },
 
   restoreTasks: function(Blueprint) {
-    Blueprint.prototype.taskFor = originTaskFor;
-    originTaskFor = undefined;
-    tasksToMock = [];
+    Blueprint.prototype.taskFor = originalTaskForFn;
+    originalTaskForFn = undefined;
   }
 };

--- a/lib/helpers/mock-blueprint-task-for.js
+++ b/lib/helpers/mock-blueprint-task-for.js
@@ -1,0 +1,30 @@
+'use strict';
+var originTaskFor;
+var Promise       = require('rsvp');
+var tasksToMock = [];
+
+module.exports = {
+  disableTasks: function(Blueprint, tasks) {
+    originTaskFor = Blueprint.prototype.taskFor;
+    tasksToMock = tasks;
+
+    Blueprint.prototype.taskFor = function(taskName) {
+
+      if (tasksToMock.indexOf(taskName) !== -1) {
+        return {
+          run: function() {
+            return Promise.resolve();
+          }
+        };
+      }
+
+      return originTaskFor.call(this, taskName);
+    };
+  },
+
+  restoreTasks: function(Blueprint) {
+    Blueprint.prototype.taskFor = originTaskFor;
+    originTaskFor = undefined;
+    tasksToMock = [];
+  }
+};

--- a/lib/helpers/mock-blueprint-task-for.js
+++ b/lib/helpers/mock-blueprint-task-for.js
@@ -1,14 +1,13 @@
 'use strict';
 var originalTaskForFn;
 var Promise     = require('rsvp');
-var tasksToMock = ['npm-install'];
 
 module.exports = {
-  disableTasks: function(Blueprint) {
+  disableTasks: function(Blueprint, tasksToMock) {
     originalTaskForFn = Blueprint.prototype.taskFor;
 
     Blueprint.prototype.taskFor = function(taskName) {
-      console.log(tasksToMock, taskName);
+
       if (tasksToMock.indexOf(taskName) !== -1) {
         return {
           run: function() {

--- a/test/disable-npm-on-blueprint.js
+++ b/test/disable-npm-on-blueprint.js
@@ -1,0 +1,28 @@
+var DisableNpmOnBlueprint = require('../lib/helpers/disable-npm-on-blueprint');
+var chai = require('chai');
+var expect = chai.expect;
+
+var DummyBlueprint = function() {};
+DummyBlueprint.prototype.taskFor = function() {
+   throw new Error('Shouldn\'t be called in context of npm tasks');
+}
+
+describe('Disable npm tasks on blueprint', function() {
+
+  beforeEach(function() {
+    DisableNpmOnBlueprint.disableNPM(DummyBlueprint);
+  });
+
+  afterEach(function() {
+    DisableNpmOnBlueprint.restoreNPM(DummyBlueprint);
+  });
+
+  it('should pass through for npm install', function() {
+    expect(new DummyBlueprint().taskFor('npm-install')).to.be.ok;
+  });
+
+  it('shouldn\'t pass through for other tasks', function() {
+    expect(function() { new DummyBlueprint().taskFor('bower-install') }).to.throw(Error);
+  });
+
+});

--- a/test/mock-blueprint-task-for.js
+++ b/test/mock-blueprint-task-for.js
@@ -1,0 +1,31 @@
+var MockBlueprintTaskFor = require('../lib/helpers/mock-blueprint-task-for');
+var chai = require('chai');
+var expect = chai.expect;
+
+var DummyBlueprint = function() {};
+DummyBlueprint.prototype.taskFor = function() {
+   throw new Error('Shouldn\'t be called');
+}
+
+describe('Disable multiple tasks on blueprint', function() {
+
+  it('should pass through for configured tasks', function() {
+    MockBlueprintTaskFor.disableTasks(DummyBlueprint, ['npm-install', 'bower-install']);
+    expect(new DummyBlueprint().taskFor('npm-install')).to.be.ok;
+    expect(new DummyBlueprint().taskFor('bower-install')).to.be.ok;
+    MockBlueprintTaskFor.restoreTasks(DummyBlueprint);
+  });
+
+  it('shouldn\'t pass through for other tasks', function() {
+    MockBlueprintTaskFor.disableTasks(DummyBlueprint, []);
+    expect(function() { new DummyBlueprint().taskFor('bower-install') }).to.throw(Error);
+    MockBlueprintTaskFor.restoreTasks(DummyBlueprint);
+  });
+
+  it('should pass through once restored', function() {
+    MockBlueprintTaskFor.disableTasks(DummyBlueprint, ['bower-install']);
+    MockBlueprintTaskFor.restoreTasks(DummyBlueprint);
+    expect(function() { new DummyBlueprint().taskFor('bower-install') }).to.throw(Error);
+  });
+
+});

--- a/test/mock-blueprint-task-for.js
+++ b/test/mock-blueprint-task-for.js
@@ -9,23 +9,22 @@ DummyBlueprint.prototype.taskFor = function() {
 
 describe('Disable multiple tasks on blueprint', function() {
 
-  it('should pass through for configured tasks', function() {
-    MockBlueprintTaskFor.disableTasks(DummyBlueprint, ['npm-install', 'bower-install']);
+  it('should pass through for pre-configured tasks', function() {
+    MockBlueprintTaskFor.disableTasks(DummyBlueprint);
     expect(new DummyBlueprint().taskFor('npm-install')).to.be.ok;
-    expect(new DummyBlueprint().taskFor('bower-install')).to.be.ok;
     MockBlueprintTaskFor.restoreTasks(DummyBlueprint);
   });
 
   it('shouldn\'t pass through for other tasks', function() {
-    MockBlueprintTaskFor.disableTasks(DummyBlueprint, []);
+    MockBlueprintTaskFor.disableTasks(DummyBlueprint);
     expect(function() { new DummyBlueprint().taskFor('bower-install') }).to.throw(Error);
     MockBlueprintTaskFor.restoreTasks(DummyBlueprint);
   });
 
   it('should pass through once restored', function() {
-    MockBlueprintTaskFor.disableTasks(DummyBlueprint, ['bower-install']);
+    MockBlueprintTaskFor.disableTasks(DummyBlueprint);
     MockBlueprintTaskFor.restoreTasks(DummyBlueprint);
-    expect(function() { new DummyBlueprint().taskFor('bower-install') }).to.throw(Error);
+    expect(function() { new DummyBlueprint().taskFor('npm-install') }).to.throw(Error);
   });
 
 });

--- a/test/mock-blueprint-task-for.js
+++ b/test/mock-blueprint-task-for.js
@@ -10,19 +10,19 @@ DummyBlueprint.prototype.taskFor = function() {
 describe('Disable multiple tasks on blueprint', function() {
 
   it('should pass through for pre-configured tasks', function() {
-    MockBlueprintTaskFor.disableTasks(DummyBlueprint);
+    MockBlueprintTaskFor.disableTasks(DummyBlueprint, ['npm-install']);
     expect(new DummyBlueprint().taskFor('npm-install')).to.be.ok;
     MockBlueprintTaskFor.restoreTasks(DummyBlueprint);
   });
 
   it('shouldn\'t pass through for other tasks', function() {
-    MockBlueprintTaskFor.disableTasks(DummyBlueprint);
+    MockBlueprintTaskFor.disableTasks(DummyBlueprint, []);
     expect(function() { new DummyBlueprint().taskFor('bower-install') }).to.throw(Error);
     MockBlueprintTaskFor.restoreTasks(DummyBlueprint);
   });
 
   it('should pass through once restored', function() {
-    MockBlueprintTaskFor.disableTasks(DummyBlueprint);
+    MockBlueprintTaskFor.disableTasks(DummyBlueprint, ['npm-install']);
     MockBlueprintTaskFor.restoreTasks(DummyBlueprint);
     expect(function() { new DummyBlueprint().taskFor('npm-install') }).to.throw(Error);
   });


### PR DESCRIPTION
`disable-npm-on-blueprint` helper nows uses this internally. Added tests for the existing helper & the new one. Fixes #22
