### PR TITLE
CI: Enable automatic NPM deployment for tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,12 @@ node_js:
   - "0.12"
 
 script: npm run coverage
+
+deploy:
+  provider: npm
+  email: stefan.penner+ember-cli@gmail.com
+  api_key:
+    secure: RazRH86kNAMreP3FnXPPpCG0qb9ljB5c/RNE6AR7JOwraYZXy8GeEIVC8vg1nUvmF7Di4yDr4TReagPfqhPz4VngeIf9p8N2JxkJm8hl4hWBrILyJ6XpTPq7QG/62PWHm6TV9g5AzoNN9QyEMlq2c1gkBIQ3rj6LwUnSyaW6M9eEvDd7Kq/epnMrWSuPEgXuMxBWBoVIKq17U3CaAP9x8nQUpgV02/hUbJz4To7S2iLLga8X8bxgK5xI7eNGZeR2H3teQAKQ4gfOgf4bcBp6PpCwZlMcBJUXXpu+yoG09eKQJ+OV8HKua2bWsRUkMklm9hJkfSNbQPXtiz/aUjtCIQkigZvfrgyFhutHiDheUH845ws+gIgdocf1+Sx2df+qfr7Xo17Vfm7+BNlDPiWuf1pACkpisWkZfdwIgmChT+MuCDYMjJwGgyNtcSQOsxsL5H6SoJQAPGQT1gn/31iIhdvsixaY3Sscx1Vc32tSippPxSeIg5n/z0+EBtgCcDR0C4LiMv304VXI67JZUNJ3EHBmug2VgLCZrRBIUtR6PB/lnAmL8MZVx5wxkr02LL2lNFHGMgFh7sr5Oo1+L37YJd2LVazkAZXy+61XzuaEanFQgUlUSaA/fAL/tjXwoXdCZO8/fC7CuXk6xRfWC4h4h2HMrYLU1jX1SB199GXlDac=
+  on:
+    tags: true
+    repo: ember-cli/ember-cli-internal-test-helpers

--- a/package.json
+++ b/package.json
@@ -5,9 +5,7 @@
   "main": "index.js",
   "scripts": {
     "coverage": "istanbul cover node_modules/mocha/bin/_mocha",
-    "test": "mocha",
-    "preversion": "npm test",
-    "postversion": "git push origin master --follow-tags && npm publish"
+    "test": "mocha"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
After merging this you no longer have to `npm publish` manually. TravisCI will test all pushed tags and deploy automatically after all tests passed.

`git owner add ember-cli` is still needed, because I didn't have the NPM owner bit to do it myself.

/cc @nathanhammond @stefanpenner @rwjblue